### PR TITLE
Update to 2020 WPILib

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "org.jetbrains.kotlin.jvm" version "1.3.50"
-    id "edu.wpi.first.GradleRIO" version "2019.4.1"
+    id "edu.wpi.first.GradleRIO" version "2020.1.2"
 }
 
 def ROBOT_MAIN_CLASS = "org.team5419.frc2020.Main"
@@ -53,6 +53,9 @@ repositories {
     }
     maven {
         url "https://first.wpi.edu/FRC/roborio/maven/release/"
+    }
+    maven {
+        url "https://frcmaven.wpi.edu/artifactory/release/"
     }
 }
 


### PR DESCRIPTION
The reason it wasn't compiling when y'all changed GradleRIO to `2020.1.2` is because the maven repo for 2020 moved to `https://frcmaven.wpi.edu/artifactory/release/`. I just added that repo to the `build.gradle` file, and now it works fine.